### PR TITLE
Test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+gemspec
 
 gem 'jekyll', '~> 3'
 gem 'minima'
-gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 3'
+gem 'minima'
 gem 'rspec'

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ In future I intend that to highlight and be a bit less clunky.
 
 * If the first thing on a document is a markdown link, it will not be detected for the `graph` or references.
 * `dm: true` does not prevent selection in collections of a document.
-* Code style/quality is not great. Tests needed.
+* Code needs to be better organized into subclasses.
 
 ## Feature roadmap
 
 * Represent relationship between geographical locations in a hierarchical way for easy navigation.
 * Make a DM block filter and clearly highlight DM only content in boxes or similar.
-* Make references table more customizeable.
+* Make references table more customizeable and potentially even a template-able thing.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In future I intend that to highlight and be a bit less clunky.
 
 * If the first thing on a document is a markdown link, it will not be detected for the `graph` or references.
 * `dm: true` does not prevent selection in collections of a document.
-* Code needs to be better organized into subclasses.
+* Code needs to be better organized into classes.
 
 ## Feature roadmap
 

--- a/jekyll-rpg.gemspec
+++ b/jekyll-rpg.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6.1'
 
   s.add_dependency 'jekyll', '~> 3'
+  s.add_development_dependency 'rspec'
 end

--- a/jekyll-rpg.gemspec
+++ b/jekyll-rpg.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6.1'
 
   s.add_dependency 'jekyll', '~> 3'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'
 end

--- a/jekyll-rpg.gemspec
+++ b/jekyll-rpg.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |s|
   s.name        = 'jekyll-rpg'
-  s.version     = '0.0.3'
-  s.date        = '2019-09-16'
+  s.version     = '0.0.4'
+  s.date        = '2019-09-19'
   s.summary     = 'Jekyll plugin for managing RPG information for DMs'
   s.description = ''
   s.authors     = ['Tom Lockwood']

--- a/jekyll-rpg.gemspec
+++ b/jekyll-rpg.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     'lib/references.rb',
     'lib/collection_page.rb'
   ]
-  s.homepage    =
+  s.homepage =
     'https://github.com/tomlockwood/jekyll-rpg'
   s.license = 'MIT'
   s.required_ruby_version = '>= 2.6.1'

--- a/lib/collection_page.rb
+++ b/lib/collection_page.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module JekyllRPG
+  # Represents a document that may be in a Jekyll collection
   class CollectionPage
     attr_accessor :name, :collection, :slug, :written
 

--- a/lib/jekyll-rpg.rb
+++ b/lib/jekyll-rpg.rb
@@ -8,7 +8,7 @@ module JekyllRPG
   Jekyll::Hooks.register :site, :post_read do |site|
     ref = References.new(site)
 
-    site.data['graph'] = ref.graph
+    site.data['graph'] = ref.hashed_graph
 
     site.data['broken_links'] = ref.broken_links
   end

--- a/lib/jekyll-rpg.rb
+++ b/lib/jekyll-rpg.rb
@@ -3,6 +3,7 @@
 require 'jekyll'
 require_relative 'references'
 
+# Generates reference information for Jekyll Site
 module JekyllRPG
   # Bi-directional page links
   Jekyll::Hooks.register :site, :post_read do |site|

--- a/lib/references.rb
+++ b/lib/references.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'collection_page'
+require 'pry'
 
 module JekyllRPG
   # References within Jekyll Collections
@@ -16,7 +17,7 @@ module JekyllRPG
       # Parse references from markdown links
       @collection_keys.each do |collection|
         @site.collections[collection].docs.each do |doc|
-          if doc.data['dm'] && !@site.data['dm_mode']
+          if doc.data['dm'] && !@site.config['dm_mode']
             doc.data['published'] = false
           else
             referent = CollectionPage.new(

--- a/lib/references.rb
+++ b/lib/references.rb
@@ -38,13 +38,13 @@ module JekyllRPG
 
           # Get the information for every page the current doc is referenced in
           # And push links to an array that represents the collections of those pages
-          referenced_in(collection, doc.data['slug'] ).each do |reference|
+          referenced_in(collection, doc.data['slug']).each do |reference|
             page_refs[reference.collection] = [] unless page_refs.key?(reference.collection)
             page_refs[reference.collection].push(reference.markdown_link)
           end
 
           # Make sure links in collections are unique
-          page_refs.each do |k,v|
+          page_refs.each do |k, v|
             page_refs[k] = v.uniq
           end
 
@@ -74,7 +74,7 @@ module JekyllRPG
     # returns link text, collection and slug
     # [0](/1/2) - as a [0, 1, 2]
     def link_components(link)
-      [link[%r{(?<=\[).*?(?=\])}], link[%r{(?<=/).*(?=/)}], link[%r{(?<=/)(?:(?!/).)*?(?=\))}]]
+      [link[/(?<=\[).*?(?=\])/], link[%r{(?<=/).*(?=/)}], link[%r{(?<=/)(?:(?!/).)*?(?=\))}]]
     end
 
     # Find a document based on its collection and slug
@@ -110,16 +110,16 @@ module JekyllRPG
 
     # Based on the graph, returns edges that a specific document is the referent of
     def referenced_in(collection, slug)
-      @graph.select {
-        |edge| edge['reference'].collection == collection && edge['reference'].slug == slug
-      }.map { |edge| edge['referent'] }
+      @graph.select do |edge|
+        edge['reference'].collection == collection && edge['reference'].slug == slug
+      end.map { |edge| edge['referent'] }
     end
 
     # Based on the graph, returns documents that are referenced, but do not exist yet
     def unwritten_pages
-      @graph.select {
-        |edge| !edge['reference'].written
-      }
+      @graph.reject do |edge|
+        edge['reference'].written
+      end
     end
 
     # Determines if refs table is required based on document,
@@ -144,7 +144,7 @@ module JekyllRPG
         'referent_name' => edge['referent'].name,
         'referent_collection' => edge['referent'].collection,
         'referent_slug' => edge['referent'].slug,
-        'referent_link' => edge['referent'].markdown_link,
+        'referent_link' => edge['referent'].markdown_link
       }
     end
 

--- a/lib/references.rb
+++ b/lib/references.rb
@@ -35,7 +35,7 @@ module JekyllRPG
 
       # For each collection page, add where it is referenced
       @collection_keys.each do |collection|
-        site.collections[collection].docs.each do |doc|
+        @site.collections[collection].docs.each do |doc|
           page_refs = {}
 
           # Get the information for every page the current doc is referenced in

--- a/lib/references.rb
+++ b/lib/references.rb
@@ -58,20 +58,9 @@ module JekyllRPG
         end
       end
 
-      #print broken_links
-
       # Create list of broken links
       unwritten_pages.each do |edge|
-        @broken_links.push({
-          'reference_name' => edge['reference'].name,
-          'reference_collection' => edge['reference'].collection,
-          'reference_slug' => edge['reference'].slug,
-          'reference_link' => edge['reference'].markdown_link,
-          'referent_name' => edge['referent'].name,
-          'referent_collection' => edge['referent'].collection,
-          'referent_slug' => edge['referent'].slug,
-          'referent_link' => edge['referent'].markdown_link,
-        })
+        @broken_links.push(edge_hash(edge))
       end
     end
 
@@ -133,6 +122,23 @@ module JekyllRPG
       elsif @site.config.key?('refs')
         @site.config['refs']
       end
+    end
+
+    def edge_hash(edge)
+      {
+        'reference_name' => edge['reference'].name,
+        'reference_collection' => edge['reference'].collection,
+        'reference_slug' => edge['reference'].slug,
+        'reference_link' => edge['reference'].markdown_link,
+        'referent_name' => edge['referent'].name,
+        'referent_collection' => edge['referent'].collection,
+        'referent_slug' => edge['referent'].slug,
+        'referent_link' => edge['referent'].markdown_link,
+      }
+    end
+
+    def hashed_graph
+      @graph.map { |edge| edge_hash(edge) }
     end
 
     def refs_table(refs)

--- a/lib/references.rb
+++ b/lib/references.rb
@@ -3,6 +3,7 @@
 require 'collection_page'
 
 module JekyllRPG
+  # References within Jekyll Collections
   class References
     attr_accessor :collection_keys, :broken_links, :graph
 

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -44,6 +44,10 @@ describe 'Make Jekyll-RPG site' do
       ).to eq nil
     end
 
+    it 'does not publish DM material' do
+      expect(site_doc_named('Nega Bruce').data['published']).to eq false
+    end
+
     it 'generates a list of broken links' do
       expect(
         @site.data['broken_links'].find do |link|

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -21,7 +21,8 @@ describe 'Make Jekyll-RPG site' do
       }
     )
     @site = Jekyll::Site.new(@config)
-    @site.process
+    @site.reset
+    @site.read
   end
 
   context 'with defaults' do
@@ -56,7 +57,7 @@ describe 'Make Jekyll-RPG site' do
 
     it 'puts a link to the referencing document on the document' do
       expect(bethany).to include(
-        '<a href="/history/slaying_of_bethany">Slaying of Bethany</a>'
+        '[Slaying of Bethany](/history/slaying_of_bethany)'
       )
     end
 

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'jekyll'
+require_relative 'spec_helper'
 
 describe 'Make Jekyll-RPG site' do
   let(:dm_mode) { false }

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -38,6 +38,12 @@ describe 'Make Jekyll-RPG site' do
       ).to eq ['[Slaying of Bethany](/history/slaying_of_bethany)']
     end
 
+    it 'does not show references from DM material' do
+      expect(
+        site_doc_named('Bethany').data['referenced_by']['gods']
+      ).to eq nil
+    end
+
     it 'generates a list of broken links' do
       expect(
         @site.data['broken_links'].find do |link|
@@ -63,6 +69,17 @@ describe 'Make Jekyll-RPG site' do
 
     it 'does not include a collection row for a collection that has no refs' do
       expect(bethany).not_to include('Gods')
+    end
+  end
+
+  context 'with dm_mode set to true' do
+    let(:dm_mode) { true }
+
+    it 'does shows references from DM material' do
+      print @site.data['dm_mode']
+      expect(
+        site_doc_named('Bethany').data['referenced_by']['gods']
+      ).to eq ['[Nega Bruce](/gods/nega_bruce)']
     end
   end
 end

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -25,7 +25,7 @@ describe 'Make Jekyll-RPG site' do
 
   context 'with defaults' do
     it 'makes a graph with nodes representing links between pages' do
-      expect(@site.data['graph'][0]['reference'].name).to eq('Slaying of Bethany')
+      expect(@site.data['graph'][0]['reference_name']).to eq('Slaying of Bethany')
     end
 
     it 'puts the references on documents' do

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -25,15 +25,23 @@ describe 'Make Jekyll-RPG site' do
 
   context 'with defaults' do
     it 'makes a graph with nodes representing links between pages' do
-      expect(@site.data['graph'][0]['reference_name']).to eq('Slaying of Bethany')
+      expect(
+        @site.data['graph'][0]['reference_name']
+      ).to eq('Slaying of Bethany')
     end
 
     it 'puts the references on documents' do
-      expect(site_doc_named('Bethany').data['referenced_by']['history']).to eq ['[Slaying of Bethany](/history/slaying_of_bethany)']
+      expect(
+        site_doc_named('Bethany').data['referenced_by']['history']
+      ).to eq ['[Slaying of Bethany](/history/slaying_of_bethany)']
     end
 
     it 'generates a list of broken links' do
-      expect(@site.data['broken_links'].find { |link| link['reference_link'] == '[Bruce](/gods/bruce)' }['reference_slug']).to eq('bruce')
+      expect(
+        @site.data['broken_links'].find do |link|
+          link['reference_link'] == '[Bruce](/gods/bruce)'
+        end['reference_slug']
+      ).to eq('bruce')
     end
   end
 
@@ -49,7 +57,7 @@ describe 'Make Jekyll-RPG site' do
       expect(bethany).to include('<a href="/history/slaying_of_bethany">Slaying of Bethany</a>')
     end
 
-    it 'does not include a collection row for a collection that has no refs to the doc' do
+    it 'does not include a collection row for a collection that has no refs' do
       expect(bethany).not_to include('Gods')
     end
   end

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -80,10 +80,13 @@ describe 'Make Jekyll-RPG site' do
     let(:dm_mode) { true }
 
     it 'does shows references from DM material' do
-      print @site.data['dm_mode']
       expect(
         site_doc_named('Bethany').data['referenced_by']['gods']
       ).to eq ['[Nega Bruce](/gods/nega_bruce)']
+    end
+
+    it 'does not block publishing dm material' do
+      expect(site_doc_named('Nega Bruce').data['published']).not_to eq false
     end
   end
 end

--- a/test/jekyll_rpg_spec.rb
+++ b/test/jekyll_rpg_spec.rb
@@ -54,7 +54,9 @@ describe 'Make Jekyll-RPG site' do
     end
 
     it 'puts a link to the referencing document on the document' do
-      expect(bethany).to include('<a href="/history/slaying_of_bethany">Slaying of Bethany</a>')
+      expect(bethany).to include(
+        '<a href="/history/slaying_of_bethany">Slaying of Bethany</a>'
+      )
     end
 
     it 'does not include a collection row for a collection that has no refs' do

--- a/test/site/_gods/nega_bruce.md
+++ b/test/site/_gods/nega_bruce.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: Nega Bruce
+name: Nega Bruce
+dm: true
+---
+
+Nega Bruce or dark [Bruce](/gods/bruce) as he is known has an intense hatred for Bruce.  Nega Bruce will one day resurrect a Nega [Bethany](/gods/bethany).

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'bundler'
+Bundler.setup
+
+require 'jekyll-rpg'


### PR DESCRIPTION
- Expanded testing
- `site.data['graph']` does not contain ruby class objects anymore - now an array of hashes of strings
- `site.config['dm_mode']` was not properly getting picked up when doing reference graph creation